### PR TITLE
Update requirements.txt to fix missing nh-currency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy==1.21.0
 Babel==2.9.1
 Pillow==9.0.1
 PyYAML==6.0
+nh-currency==1.0.1


### PR DESCRIPTION
The current requirements are missing nh-currency==1.0.1 

https://github.com/veebch/btcticker/issues/89 even says it is required.